### PR TITLE
Make minor visual improvements

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,9 +3,12 @@
 <title>Upstreamed commits &ndash; Opera</title>
 <style>
 body { font-family: sans-serif; }
-table { width: 100%; }
+table { border-collapse: collapse; border-spacing: 0; width: 100%; }
+tbody tr:hover { background: #f5f5f5; }
 td { vertical-align: top; }
+td, th { padding: 7px; }
 th { text-align: left; }
+tr { border-bottom: 1px dashed #aaa; }
 a { color: #900; transition: 0.4s color; }
 a:visited { color: #755; }
 a:hover { color: #f00; }
@@ -16,6 +19,7 @@ h1 { margin-top: 0; text-align: center; }
 .hint { color: #666; font-size: 0.8em; }
 .col-author { width: 160px; }
 .col-when { width: 130px; }
+.message { cursor: pointer; }
 </style>
 
 {% block content %}

--- a/templates/upstreamed_commits.html
+++ b/templates/upstreamed_commits.html
@@ -15,7 +15,8 @@
       <colgroup class=col-author>
       <colgroup class=col-message>
       <colgroup class=col-when>
-      <tr><th>Author <th>Message <th>When
+      <thead><tr><th>Author <th>Message <th>When
+      <tbody>
       {% for c in project.log %}
         <tr>
           <td>{{ c.author_stripped|e }}


### PR DESCRIPTION
Changes:
- Added `cursor: pointer;` to further indicate that the commit message title can be clicked (on my first visit, I completely missed the `Click message to expand` message, and it took me a few seconds to figure it out, especially as Firefox does not support `<details>/<summary>`, and thus, the <img src="https://f.cloud.github.com/assets/1223565/2504124/ad84155a-b389-11e3-8602-bd9ba25a23bc.png" width=20 height=20> sign is not displayed)
- Made lines easier to read by making other minor improvements.
## 

Web page: [before](http://operasoftware.github.io/upstreamtools/) / [after](http://jsbin.com/cejikoyu/1) (had to remove some of the content due to JS Bin [size limit](https://f.cloud.github.com/assets/1223565/2504027/ae7fb604-b388-11e3-83c5-bf847d4cdbb0.png))

Screenshots:

| Browser | Before | After |
| :-- | :-- | :-- |
| Firefox | <img src="https://f.cloud.github.com/assets/1223565/2503998/4a769dbc-b388-11e3-845d-29939d9c4c94.png" width=200 height=100> | <img src="https://f.cloud.github.com/assets/1223565/2503997/499a8296-b388-11e3-9016-d9c9899fa300.png" width=200 height=100> |
| Opera | <img src="https://f.cloud.github.com/assets/1223565/2503999/4b6e6d26-b388-11e3-9adc-1485094c8979.png" width=200 height=100> | <img src="https://f.cloud.github.com/assets/1223565/2504000/4cac3b5a-b388-11e3-8c9a-010a3176b619.png" width=200 height=100> |

(Cc: @mathiasbynens)
